### PR TITLE
RORの値のチェックを修正

### DIFF
--- a/spec/example/3_creator/affiliation_name_identifier_content_is_uri_ror.xml
+++ b/spec/example/3_creator/affiliation_name_identifier_content_is_uri_ror.xml
@@ -19,7 +19,7 @@
         <jpcoar:creatorName xml:lang="en">Adachi, Jun</jpcoar:creatorName>
         <jpcoar:creatorName xml:lang="ja-Kana">アダチ, ジュン</jpcoar:creatorName>
         <jpcoar:affiliation>
-            <jpcoar:nameIdentifier nameIdentifierScheme="ROR" nameIdentifierURI="https://ror.org/057zh3y96">https://ror.org/057zh3y96</jpcoar:nameIdentifier>
+            <jpcoar:nameIdentifier nameIdentifierScheme="ROR" nameIdentifierURI="https://ror.org/057zh3y96">057zh3y96</jpcoar:nameIdentifier>
             <jpcoar:affiliationName xml:lang="ja">東京大学</jpcoar:affiliationName>
             <jpcoar:affiliationName xml:lang="en">The University of Tokyo</jpcoar:affiliationName>
         </jpcoar:affiliation>

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe JPCOARValidator do
       doc = LibXML::XML::Document.file(File.join(spec_base_dir, "example/3_creator/affiliation_name_identifier_content_is_uri_ror.xml"))
       results = validator.validate_jpcoar(doc)
       expect(results[:warn].map{|e| e[:error_id]}).not_to include(:nameidentifier_content_is_uri)
+      expect(results[:warn].map{|e| e[:error_id]}).not_to include(:nameIdentifier_mismatch)
     end
     it "should check nameIdentifierScheme_obsolete" do
       validator = JPCOARValidator.new("")

--- a/validator.rb
+++ b/validator.rb
@@ -56,7 +56,7 @@ class JPCOARValidator
       kakenhi: /\A\d{5}\z/,
       Ringgold: /\ARIN[0-9]+\z/,
       GRID: /\Agrid\.[0-9]+\.[0-9a-z]+\z/,
-      ROR: /\Ahttps:\/\/ror\.org\/.+\z/,
+      ROR: /\A0[a-hj-km-np-tv-z|0-9]{6}[0-9]{2}\z/,
    }
    NAME_IDENTIFIER_URI_REGEXP = {
       #"e-Rad_Researcher": /\A\d{8}\z/,


### PR DESCRIPTION
便利なサービスを作ってくださいまして、ありがとうございます。

RORの値のチェックを修正するPRです。さっそく本バリデーターを試したところ、RORを出力している箇所に対して以下の警告が出力されました。

```
nameIdentifier value is mismatch: ROR - 026v1ze26 [[#nameIdentifier_mismatch?]](https://github.com/masao/jpcoar-validator/wiki/Help#user-content-nameIdentifier_mismatch)
for [oai:mdr.nims.go.jp:75fc597c-c2dc-4b1a-8a55-9e18ea184979](https://mdr.nims.go.jp/oai?verb=GetRecord&identifier=oai:mdr.nims.go.jp:75fc597c-c2dc-4b1a-8a55-9e18ea184979&metadataPrefix=jpcoar_2.0)
```

以下がOAI-PMHの出力の該当箇所になります。

```xml
<jpcoar:nameIdentifier nameIdentifierScheme="ROR" nameIdentifierURI="https://ror.org/026v1ze26">026v1ze26</jpcoar:nameIdentifier>
```

本バリデーターではRORに対してURI形式を要求していますが、JPCOARスキーマのガイドラインでは「jpcoar:nameIdentifierの値は接頭辞等の情報を付けず、IDのみを記入する。」とされています。このため、このPRで、IDの部分のみに対して値のチェックを行うように修正しています。
https://github.com/masao/jpcoar-validator/blob/main/validator.rb#L59
https://schema.irdb.nii.ac.jp/ja/schema/2.0/3-.6-.1

なお、RORのIDの値の正規表現パターンは、RORのドキュメントに記載されているものを使用しています。  
https://ror.readme.io/docs/identifier